### PR TITLE
Improve candidate visualization

### DIFF
--- a/bin/lts-candidate-stats
+++ b/bin/lts-candidate-stats
@@ -86,7 +86,7 @@ class Script {
     static String ageIndicator(it) {
         def releasedAs = it.customfields.customfield.find { it.customfieldname == "Released As" }.customfieldvalues as String
         if (releasedAs?.trim()) {
-            return releasedAs.replaceAll("[Jj]enkins ", "")
+            return releasedAs.replaceAll("[Jj]enkins[ -]", "")
         } else {
             return it.updated
         }

--- a/bin/lts-candidate-stats
+++ b/bin/lts-candidate-stats
@@ -61,12 +61,15 @@ class Script {
 
                 def age = Ansi.color(ageIndicator(it), Ansi.YELLOW)
                 println "${it.key}\t\t${prio}\t\t${age}"
-                def labels = it.labels.label.collect { it.toString() }
-                if ('non-trivial-lts-backporting' in labels){
-                    println "\t${Ansi.color('non-trivial-lts-backporting', Ansi.RED)}"
-                }
                 println "\t${it.summary}"
+
+                def labels = it.labels.label.collect { it.toString() }
+                labels.retainAll(['non-trivial-lts-backporting', 'regression'])
+                if (!labels.empty){
+                    println "\t${Ansi.color(labels.join(' '), Ansi.RED)}"
+                }
                 println "\t${it.link}"
+
                 it.issuelinks.issuelinktype.each {
                     if (it.name.toString() == 'Cause') {
                         it.outwardlinks.issuelink.each {

--- a/bin/lts-candidate-stats
+++ b/bin/lts-candidate-stats
@@ -54,15 +54,30 @@ class Script {
             for (it in items) {
                 def prio = it.priority.toString()
                 if (prio.toLowerCase() in ['blocker', 'critical']) {
-                    prio = Ansi.color(prio, Ansi.RED)
+                    prio = Ansi.color(prio.padRight(10), Ansi.RED)
+                } else {
+                    prio = prio.padRight(10)
                 }
-
-                prio = prio.padRight(10)
 
                 def age = Ansi.color(ageIndicator(it), Ansi.YELLOW)
                 println "${it.key}\t\t${prio}\t\t${age}"
+                def labels = it.labels.label.collect { it.toString() }
+                if ('non-trivial-lts-backporting' in labels){
+                    println "\t${Ansi.color('non-trivial-lts-backporting', Ansi.RED)}"
+                }
                 println "\t${it.summary}"
                 println "\t${it.link}"
+                it.issuelinks.issuelinktype.each {
+                    if (it.name.toString() == 'Cause') {
+                        it.outwardlinks.issuelink.each {
+                            def caused = Ansi.color(
+                                "Caused https://issues.jenkins-ci.org/browse/${it.toString()}",
+                                Ansi.RED
+                            )
+                            println "\t\t$caused"
+                        }
+                    }
+                }
                 println ""
             }
         }

--- a/bin/lts-candidate-stats
+++ b/bin/lts-candidate-stats
@@ -49,13 +49,20 @@ class Script {
 
     static void printListing(String title, items) {
         if (!items.isEmpty()) {
-            println "${title}:"
+            println "${title}\n${''.padRight(title.length(), '-')}\n"
 
             for (it in items) {
-                def prio = it.priority.toString().padRight(10)
-                println "\t${it.key}\t\t${prio}\t\t${ageIndicator(it)}"
-                println "\t\t${it.summary}"
-                println "\t\t${it.link}"
+                def prio = it.priority.toString()
+                if (prio.toLowerCase() in ['blocker', 'critical']) {
+                    prio = Ansi.color(prio, Ansi.RED)
+                }
+
+                prio = prio.padRight(10)
+
+                def age = Ansi.color(ageIndicator(it), Ansi.YELLOW)
+                println "${it.key}\t\t${prio}\t\t${age}"
+                println "\t${it.summary}"
+                println "\t${it.link}"
                 println ""
             }
         }
@@ -64,9 +71,44 @@ class Script {
     static String ageIndicator(it) {
         def releasedAs = it.customfields.customfield.find { it.customfieldname == "Released As" }.customfieldvalues as String
         if (releasedAs?.trim()) {
-            return releasedAs
+            return releasedAs.replaceAll("[Jj]enkins ", "")
         } else {
             return it.updated
+        }
+    }
+
+    // Credit https://gist.github.com/tvinke/db4d21dfdbdae49e6f92dcf1ca6120de
+    private static class Ansi {
+
+        static final String NORMAL          = "\u001B[0m"
+
+        static final String BOLD            = "\u001B[1m"
+        static final String ITALIC          = "\u001B[3m"
+        static final String UNDERLINE       = "\u001B[4m"
+        static final String BLINK           = "\u001B[5m"
+        static final String RAPID_BLINK     = "\u001B[6m"
+        static final String REVERSE_VIDEO   = "\u001B[7m"
+        static final String INVISIBLE_TEXT  = "\u001B[8m"
+
+        static final String BLACK           = "\u001B[30m"
+        static final String RED             = "\u001B[31m"
+        static final String GREEN           = "\u001B[32m"
+        static final String YELLOW          = "\u001B[33m"
+        static final String BLUE            = "\u001B[34m"
+        static final String MAGENTA         = "\u001B[35m"
+        static final String CYAN            = "\u001B[36m"
+        static final String WHITE           = "\u001B[37m"
+
+        static final String DARK_GRAY       = "\u001B[1;30m"
+        static final String LIGHT_RED       = "\u001B[1;31m"
+        static final String LIGHT_GREEN     = "\u001B[1;32m"
+        static final String LIGHT_YELLOW    = "\u001B[1;33m"
+        static final String LIGHT_BLUE      = "\u001B[1;34m"
+        static final String LIGHT_PURPLE    = "\u001B[1;35m"
+        static final String LIGHT_CYAN      = "\u001B[1;36m"
+
+        static String color(String text, String ansiValue) {
+            ansiValue + text + NORMAL
         }
     }
 }


### PR DESCRIPTION
Improve the way the LTS candidates are visualized during backporting to highlight that

- backportign is non-trivial for an issue
- there are caused issues

This is mostly to make it harder not to notice.

![screenshot](https://user-images.githubusercontent.com/206841/78021401-7758a780-7353-11ea-9b91-ecb515574915.png)

@oleg-nenashev, @daniel-beck, FYI