### PR TITLE
Update Jira URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There is a couple of manual tasks that needs to follow described in the output.
 
 ### Backporting
 
-Process through [LTS Candidates](https://issues.jenkins-ci.org/issues/?filter=12146) and update label `lts-candidate` to `${VERSION}-fixed` or `${VERSION}-rejected`. See `lts-candidate-stats <next_lts_version>` for status report.
+Process through [LTS Candidates](https://issues.jenkins.io/issues/?filter=12146) and update label `lts-candidate` to `${VERSION}-fixed` or `${VERSION}-rejected`. See `lts-candidate-stats <next_lts_version>` for status report.
 
 #### Identify issue commits
 

--- a/bin/generate-backporting-announcement
+++ b/bin/generate-backporting-announcement
@@ -7,9 +7,9 @@ fi
 
 body="Backporting has started and the RC is scheduled for $(/usr/bin/date -d 'next Wednesday + 1 week' '+%Y-%m-%d'). <<< !!! CHECK THE DATE !!!
 
-Candidates: https://issues.jenkins-ci.org/issues/?filter=12146
-Fixed: https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20$1-fixed
-Rejected: https://issues.jenkins-ci.org/issues/?jql=labels%20%3D%20$1-rejected
+Candidates: https://issues.jenkins.io/issues/?filter=12146
+Fixed: https://issues.jenkins.io/issues/?jql=labels%20%3D%20$1-fixed
+Rejected: https://issues.jenkins.io/issues/?jql=labels%20%3D%20$1-rejected
 
 "
 

--- a/bin/generate-lts-changelog
+++ b/bin/generate-lts-changelog
@@ -52,7 +52,7 @@ class Script {
     def tagged = []
 
     String dump = new URL(
-      "https://issues.jenkins-ci.org/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jqlQuery=project+%3D+Jenkins+%26%26+labels+in+%28${version}-fixed%29&tempMax=1000"
+      "https://issues.jenkins.io/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jqlQuery=project+%3D+Jenkins+%26%26+labels+in+%28${version}-fixed%29&tempMax=1000"
     ).text
 
     def rss = new XmlSlurper().parseText(dump)
@@ -116,7 +116,7 @@ class Script {
   }
 
   static String getIssueUrl(String id) {
-    return "https://issues.jenkins-ci.org/browse/$id"
+    return "https://issues.jenkins.io/browse/$id"
   }
 
   // Get changelog entries as formulated for weekly releases since the baseline

--- a/bin/lts-candidate-stats
+++ b/bin/lts-candidate-stats
@@ -3,7 +3,7 @@
 class Script {
 
 
-    private static final String PREFIX = "https://issues.jenkins-ci.org/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?tempMax=1000&jqlQuery=";
+    private static final String PREFIX = "https://issues.jenkins.io/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?tempMax=1000&jqlQuery=";
 
     static int main(String[] args) {
 
@@ -28,7 +28,7 @@ class Script {
         categories['Postponed'] = [];
         categories['Rejected'] = fetch(PREFIX + "labels+in+%28${version}-rejected%29").toList()
         categories['Fixed'] = fetch(PREFIX + "labels+in+%28${version}-fixed%29").toList()
-        categories['Candidates'] = fetch("https://issues.jenkins-ci.org/sr/jira.issueviews:searchrequest-xml/12146/SearchRequest-12146.xml?tempMax=1000").toList()
+        categories['Candidates'] = fetch("https://issues.jenkins.io/sr/jira.issueviews:searchrequest-xml/12146/SearchRequest-12146.xml?tempMax=1000").toList()
 
         categories['Postponed'] = categories['Candidates'].findAll { c ->
            categories['Rejected'].find { it.key == c.key }
@@ -74,7 +74,7 @@ class Script {
                     if (it.name.toString() == 'Cause') {
                         it.outwardlinks.issuelink.each {
                             def caused = Ansi.color(
-                                "Caused https://issues.jenkins-ci.org/browse/${it.toString()}",
+                                "Caused https://issues.jenkins.io/browse/${it.toString()}",
                                 Ansi.RED
                             )
                             println "\t\t$caused"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-
   <groupId>org.jenkins-ci.backend</groupId>
   <artifactId>backend-commit-history-parser</artifactId>
   <name>Parses commit history and generate list</name>

--- a/src/main/java/org/jenkinsci/backend/gitlogparser/ChangeLogGenerator.groovy
+++ b/src/main/java/org/jenkinsci/backend/gitlogparser/ChangeLogGenerator.groovy
@@ -44,7 +44,7 @@ class ChangeLogGenerator extends App {
             w << "  <li class='${clazz}'>\n"
             w << "    ${summary}\n"
             if (i.key.startsWith("JENKINS-"))
-                w << "    (<a href='https://issues.jenkins-ci.org/browse/${i.key}'>issue ${n}</a>)\n"
+                w << "    (<a href='https://issues.jenkins.io/browse/${i.key}'>issue ${n}</a>)\n"
             else
                 w << "    (SECURITY-${n})\n"
         }

--- a/src/main/java/org/jenkinsci/backend/gitlogparser/TicketDetailLoader.groovy
+++ b/src/main/java/org/jenkinsci/backend/gitlogparser/TicketDetailLoader.groovy
@@ -15,7 +15,7 @@ class TicketDetailLoader {
     private Map<String,RemoteIssue> cache = [:];
 
     TicketDetailLoader() {
-        jira = JIRA.connect(new URL("https://issues.jenkins-ci.org/"))
+        jira = JIRA.connect(new URL("https://issues.jenkins.io/"))
         def props = new Properties()
         props.load(new FileReader("${System.properties["user.home"]}/.jenkins-ci.org"))
         token = jira.login(props['userName'], props['password'])

--- a/src/main/java/org/jenkinsci/backend/gitlogparser/cherry-pick.html.gsp
+++ b/src/main/java/org/jenkinsci/backend/gitlogparser/cherry-pick.html.gsp
@@ -32,7 +32,7 @@
         <td>${app.jiraStatus(i.status)}</td>
         <td>${app.jiraResolution(i.resolution)}</td>
         <td>${app.jiraType(i.type)}</td>
-        <td><a href="https://issues.jenkins-ci.org/browse/${i.key}">${i.summary}</a></td>
+        <td><a href="https://issues.jenkins.io/browse/${i.key}">${i.summary}</a></td>
       </tr>
     <% } %>
   </tbody>


### PR DESCRIPTION
We're using jenkins.io over jenkins-ci.org, the change proposed ensures the legacy URL does no longer occur in backporting emails and other locations.