### PR TITLE
chore: Clone repositories via HTTPS instead of SSH

### DIFF
--- a/bin/init-lts-line
+++ b/bin/init-lts-line
@@ -27,7 +27,7 @@ git commit -m "Towards ${baseline}.1"
 # Create dedicated packaging branch
 packaging="$(mktemp -d /tmp/jenkins-lts-rc-packaging-XXXXXXXX)"
 trap "rm -rf '$packaging'" EXIT
-git clone git@github.com:jenkinsci/packaging.git "$packaging"
+git clone https://github.com/jenkinsci/packaging.git "$packaging"
 pushd "$packaging"
 git checkout -b "$branch_name" master
 git push -u origin "$branch_name"

--- a/bin/publish-lts-rc
+++ b/bin/publish-lts-rc
@@ -21,7 +21,7 @@ WAR_FILE="$(pwd)/war/target/jenkins.war"
 packaging_ref="$(cat packaging-ref.txt)"
 packaging="$(mktemp -d /tmp/jenkins-lts-rc-packaging-XXXXXXXX)"
 trap "rm -rf '$packaging'" EXIT
-git clone -b "$packaging_ref" --single-branch git@github.com:jenkinsci/packaging.git "$packaging"
+git clone -b "$packaging_ref" --single-branch https://github.com/jenkinsci/packaging.git "$packaging"
 pushd "$packaging"
 echo "Bulding with packaging $packaging_ref"
 make WAR="$WAR_FILE" BRAND=./branding/jenkins-stable-rc.mk BUILDENV=./env/release.mk war.publish


### PR DESCRIPTION
Cloning via HTTPS and SSH are exchangeable in this case, the former just does't require you to have an SSH key added to the account.