### PR TITLE
Add import statement to lts-candidate-stats

### DIFF
--- a/bin/lts-candidate-stats
+++ b/bin/lts-candidate-stats
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
+import groovy.xml.XmlSlurper;
 
 class Script {
-
 
     private static final String PREFIX = "https://issues.jenkins.io/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?tempMax=1000&jqlQuery=";
 
@@ -39,7 +39,7 @@ class Script {
         categories.each { title, issues ->
             printListing(title, issues)
         }
-        return 0
+        return
     }
 
     static Iterable fetch(String jql) {


### PR DESCRIPTION
Fixes #15 

## Description
Fix some bugs in the `lts-candidate-stats` script: 
1. Added an import statement for importing `XmlSlurper`
2. Remove the `0` from the `return 0` in L42 to get rid of the error `Cannot return an object from a method that returns 'void'` 