### PR TITLE
Fix remaining bug in lts-candidate-stats script

### DIFF
--- a/bin/lts-candidate-stats
+++ b/bin/lts-candidate-stats
@@ -5,7 +5,7 @@ class Script {
 
     private static final String PREFIX = "https://issues.jenkins.io/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?tempMax=1000&jqlQuery=";
 
-    static int main(String[] args) {
+    static Integer main(String[] args) {
 
         if (args.size() != 1) {
             System.err.println("Usage lts-candidate-stats <version>")


### PR DESCRIPTION
Currently if I run the command
```shell
~/backend-commit-history-parser/bin/lts-candidate-stats 2.361.2
```
I would get the error
```shell
Caught: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'null' with class 'null' to class 'int'. Try 'java.lang.Integer' instead
org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'null' with class 'null' to class 'int'. Try 'java.lang.Integer' instead
        at Script.main(lts-candidate-stats:42)
```

So I would like to propose a fix of using the `Integer` type in lieu of the `int` type for the return type of the `main` function in the `lts-candidate-stats` script.